### PR TITLE
Add support for In Memory JDBC cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Javadocs](http://www.javadoc.io/badge/com.qwazr/jdbc-cache-driver.svg)](http://www.javadoc.io/doc/com.qwazr/jdbc-cache-driver)
 [![Coverage Status](https://coveralls.io/repos/github/qwazr/jdbc-cache-driver/badge.svg?branch=master)](https://coveralls.io/github/qwazr/jdbc-cache-driver?branch=master)
 
-JDBC-Driver-Cache is JDBC cache which store the result of a SQL query (ResultSet) in files.
+JDBC-Driver-Cache is JDBC cache which store the result of a SQL query (ResultSet) in files or in memory.
 The same query requested again will be read from the file, the database is no more requested again.
 
 You may use it to easily mock ResultSets from a database.
@@ -42,17 +42,29 @@ Class.forName("com.qwazr.jdbc.cache.Driver");
 Properties info = new Properties();
 info.setProperty("cache.driver.url", "jdbc:derby:memory:myDB;create=true");
 info.setProperty("cache.driver.class", "org.apache.derby.jdbc.EmbeddedDriver");
+```
 
+Use the file cache implementation:
+
+```java
 // Get your JDBC connection
 Connection cnx = DriverManager.getConnection("jdbc:cache:file:/var/jdbc/cache", info);
+```
+
+Or use the in memory cache implementation:
+
+```java
+// Get your JDBC connection
+Connection cnx = DriverManager.getConnection("jdbc:cache:mem:my-memory-cache", info);
 ```
 
 To build a connection you have to provide the URL and some properties.
 The URL tells the driver where to store the cached ResultSet.
 
-The syntax of the URL is:
+The syntax of the URL can be:
 
-*jdbc:cache:file:{path-to-the-cache-directory}*
+* *jdbc:cache:file:{path-to-the-cache-directory}* for on disk cache
+* *jdbc:cache:mem:{name-of-the-cache}* for in memory cache
 
 Two possible properties:
 - **cache.driver.url** contains the typical JDBC URL of the backend driver.

--- a/src/main/java/com/qwazr/jdbc/cache/CachedCallableStatement.java
+++ b/src/main/java/com/qwazr/jdbc/cache/CachedCallableStatement.java
@@ -29,7 +29,7 @@ class CachedCallableStatement extends CachedPreparedStatement<CallableStatement>
 
     private final SortedMap<String, Object> namedParameters;
 
-    CachedCallableStatement(final CachedConnection connection, final ResultSetCacheImpl resultSetCache,
+    CachedCallableStatement(final CachedConnection connection, final ResultSetCache resultSetCache,
             final CallableStatement backendStatement, final String sql, final int resultSetConcurrency,
             final int resultSetType, final int resultSetHoldability) {
         super(connection, resultSetCache, backendStatement, sql, resultSetConcurrency, resultSetType,
@@ -37,7 +37,7 @@ class CachedCallableStatement extends CachedPreparedStatement<CallableStatement>
         this.namedParameters = new TreeMap<>();
     }
 
-    CachedCallableStatement(final CachedConnection connection, final ResultSetCacheImpl resultSetCache,
+    CachedCallableStatement(final CachedConnection connection, final ResultSetCache resultSetCache,
             final CallableStatement backendStatement, final String sql) {
         this(connection, resultSetCache, backendStatement, sql, 0, 0, 0);
     }

--- a/src/main/java/com/qwazr/jdbc/cache/CachedConnection.java
+++ b/src/main/java/com/qwazr/jdbc/cache/CachedConnection.java
@@ -33,9 +33,9 @@ class CachedConnection implements Connection {
     private volatile String schema;
 
     private final Connection connection;
-    private final ResultSetCacheImpl resultSetCache;
+    private final ResultSetCache resultSetCache;
 
-    CachedConnection(final Connection backendConnection, final ResultSetCacheImpl resultSetCache) throws SQLException {
+    CachedConnection(final Connection backendConnection, final ResultSetCache resultSetCache) throws SQLException {
         this.connection = backendConnection;
         this.resultSetCache = resultSetCache;
         this.autocommit = false;
@@ -49,7 +49,7 @@ class CachedConnection implements Connection {
         this.schema = null;
     }
 
-    ResultSetCacheImpl getResultSetCache() {
+    ResultSetCache getResultSetCache() {
         return resultSetCache;
     }
 

--- a/src/main/java/com/qwazr/jdbc/cache/CachedInMemoryResultSet.java
+++ b/src/main/java/com/qwazr/jdbc/cache/CachedInMemoryResultSet.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016-2017 Emmanuel Keller / QWAZR
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.qwazr.jdbc.cache;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.sql.SQLException;
+
+/**
+ * Uses ByteArrayInputStream/ByteArrayOutputStream as the storage implementation.
+ * Everything is hold in memory.
+ * Warning: this is a super naive implementation. Not designed to run in production
+ * as lot of memory is going to be used by converting to byte[].
+ */
+class CachedInMemoryResultSet extends CachedResultSet {
+    CachedInMemoryResultSet(final CachedStatement statement, ByteArrayOutputStream outputStream) throws SQLException {
+        super(statement, new DataInputStream(new ByteArrayInputStream(outputStream.toByteArray())));
+    }
+}

--- a/src/main/java/com/qwazr/jdbc/cache/CachedOnDiskResultSet.java
+++ b/src/main/java/com/qwazr/jdbc/cache/CachedOnDiskResultSet.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016-2017 Emmanuel Keller / QWAZR
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.qwazr.jdbc.cache;
+
+import java.io.DataInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.util.zip.GZIPInputStream;
+
+/**
+ * Uses disk persistence for caching
+ */
+class CachedOnDiskResultSet extends CachedResultSet {
+    CachedOnDiskResultSet(final CachedStatement statement, final Path resultSetPath) throws SQLException, IOException {
+        super(statement, new DataInputStream(new GZIPInputStream(new FileInputStream(resultSetPath.toFile()))));
+    }
+}

--- a/src/main/java/com/qwazr/jdbc/cache/CachedPreparedStatement.java
+++ b/src/main/java/com/qwazr/jdbc/cache/CachedPreparedStatement.java
@@ -28,7 +28,7 @@ class CachedPreparedStatement<T extends PreparedStatement> extends CachedStateme
 
     final SortedMap<Integer, Object> parameters;
 
-    CachedPreparedStatement(final CachedConnection connection, final ResultSetCacheImpl resultSetCache,
+    CachedPreparedStatement(final CachedConnection connection, final ResultSetCache resultSetCache,
             final T backendStatement, final String sql, final int resultSetConcurrency, final int resultSetType,
             final int resultSetHoldability) {
         super(connection, resultSetCache, backendStatement, resultSetConcurrency, resultSetType, resultSetHoldability);
@@ -36,7 +36,7 @@ class CachedPreparedStatement<T extends PreparedStatement> extends CachedStateme
         this.executedSql = sql;
     }
 
-    CachedPreparedStatement(final CachedConnection connection, final ResultSetCacheImpl resultSetCache,
+    CachedPreparedStatement(final CachedConnection connection, final ResultSetCache resultSetCache,
             final T backendStatement, final String sql) {
         this(connection, resultSetCache, backendStatement, sql, 0, 0, 0);
     }
@@ -55,7 +55,7 @@ class CachedPreparedStatement<T extends PreparedStatement> extends CachedStateme
     @Override
     public ResultSet executeQuery() throws SQLException {
         generateKey();
-        return resultSetCache.get(this, generatedKey, backendStatement != null ? backendStatement::executeQuery : null);
+        return resultSetCache.get(this, generatedKey, backendStatement != null ? () -> backendStatement.executeQuery() : null);
     }
 
     @Override

--- a/src/main/java/com/qwazr/jdbc/cache/CachedStatement.java
+++ b/src/main/java/com/qwazr/jdbc/cache/CachedStatement.java
@@ -16,6 +16,7 @@
 package com.qwazr.jdbc.cache;
 
 import javax.xml.bind.DatatypeConverter;
+import java.io.IOException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.sql.Connection;
@@ -28,7 +29,7 @@ import java.sql.Statement;
 class CachedStatement<T extends Statement> implements Statement {
 
     private final CachedConnection connection;
-    final ResultSetCacheImpl resultSetCache;
+    final ResultSetCache resultSetCache;
     final T backendStatement;
 
     private final int resultSetConcurrency;
@@ -47,7 +48,7 @@ class CachedStatement<T extends Statement> implements Statement {
     volatile String executedSql;
     volatile String generatedKey;
 
-    CachedStatement(final CachedConnection connection, final ResultSetCacheImpl resultSetCache,
+    CachedStatement(final CachedConnection connection, final ResultSetCache resultSetCache,
             final T backendStatement, final int resultSetConcurrency, final int resultSetType,
             final int resultSetHoldability) {
         this.connection = connection;
@@ -67,7 +68,7 @@ class CachedStatement<T extends Statement> implements Statement {
         this.executedSql = null;
     }
 
-    CachedStatement(final CachedConnection connection, final ResultSetCacheImpl resultSetCache,
+    CachedStatement(final CachedConnection connection, final ResultSetCache resultSetCache,
             final T backendStatement) {
         this(connection, resultSetCache, backendStatement, 0, 0, 0);
     }

--- a/src/main/java/com/qwazr/jdbc/cache/ResultSetCache.java
+++ b/src/main/java/com/qwazr/jdbc/cache/ResultSetCache.java
@@ -15,6 +15,8 @@
  */
 package com.qwazr.jdbc.cache;
 
+import java.io.IOException;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
@@ -58,4 +60,12 @@ public interface ResultSetCache {
      * @return true if a cache entry is currently build for the given statement
      */
     boolean active(Statement stmt) throws SQLException;
+
+    <T extends Statement> ResultSet get(CachedStatement statement, String key, Provider s) throws SQLException;
+
+    boolean checkIfExists(String key);
+
+    interface Provider {
+        ResultSet provide() throws SQLException, IOException;
+    }
 }

--- a/src/main/java/com/qwazr/jdbc/cache/ResultSetInMemoryCacheImpl.java
+++ b/src/main/java/com/qwazr/jdbc/cache/ResultSetInMemoryCacheImpl.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2016-2017 Emmanuel Keller / QWAZR
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.qwazr.jdbc.cache;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+class ResultSetInMemoryCacheImpl extends ResultSetCacheImpl {
+
+    private final ConcurrentHashMap<String, ReentrantLock> activeKeys;
+    private final ConcurrentHashMap<String, ByteArrayOutputStream> cache;
+
+    ResultSetInMemoryCacheImpl() {
+        this.activeKeys = new ConcurrentHashMap<>();
+        this.cache = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Return the cached ResultSet for the given key.
+     * If the entry does not exist the ResultSet is extracted by calling the given resultSetProvider.
+     * If the entry does not exist and no resultSetProvider is given (null) an SQLException is thrown.
+     *
+     * @param statement         the cached statement
+     * @param key               the generated key for this statement
+     * @param resultSetProvider the optional result provider
+     * @return the cached ResultSet
+     * @throws SQLException if the statement cannot be executed
+     */
+    public ResultSet get(final CachedStatement statement, final String key, final ResultSetCache.Provider resultSetProvider)
+            throws SQLException {
+        if (!cache.containsKey(key)) {
+            if (resultSetProvider == null)
+                throw new SQLException("No cache available");
+            try {
+                buildCache(key, resultSetProvider);
+            } catch (IOException e) {
+                throw new SQLException("Can not read cache", e);
+            }
+        }
+        return new CachedInMemoryResultSet(statement, cache.get(key));
+    }
+
+    private void buildCache(final String key, final Provider resultSetProvider)
+            throws SQLException, IOException {
+        final Lock keyLock = activeKeys.computeIfAbsent(key, s -> new ReentrantLock(true));
+        try {
+            keyLock.lock();
+            try {
+                final ResultSet providedResultSet = resultSetProvider.provide();
+                ByteArrayOutputStream outputStream = ResultSetWriter.write(providedResultSet);
+                cache.put(key, outputStream);
+            } finally {
+                keyLock.unlock();
+            }
+        } finally {
+            activeKeys.remove(key);
+        }
+    }
+
+    /**
+     * Check if an entry is available for this key.
+     *
+     * @param key the computed key
+     * @return always true if the cache entry exists
+     */
+
+    public boolean checkIfExists(final String key) {
+        return cache.containsKey(key);
+    }
+
+    @Override
+    public void flush() throws SQLException {
+        cache.clear();
+    }
+
+    @Override
+    public void flush(final Statement stmt) throws SQLException {
+        cache.remove(checkKey(stmt));
+    }
+
+    @Override
+    public int size() throws SQLException {
+        return cache.size();
+    }
+
+    @Override
+    public boolean exists(Statement stmt) throws SQLException {
+        return cache.containsKey(checkKey(stmt));
+    }
+}

--- a/src/main/java/com/qwazr/jdbc/cache/ResultSetOnDiskCacheImpl.java
+++ b/src/main/java/com/qwazr/jdbc/cache/ResultSetOnDiskCacheImpl.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2016-2017 Emmanuel Keller / QWAZR
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.qwazr.jdbc.cache;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+
+class ResultSetOnDiskCacheImpl extends ResultSetCacheImpl {
+
+    private final Path cacheDirectory;
+    private final ConcurrentHashMap<String, ReentrantLock> activeKeys;
+
+    ResultSetOnDiskCacheImpl(final Path cacheDirectory) {
+        if (!Files.exists(cacheDirectory)) {
+            try {
+                Files.createDirectories(cacheDirectory);
+            } catch (IOException e) {
+                throw CacheException.of("Cannot create the cache directory: " + cacheDirectory, e);
+            }
+        }
+        if (!Files.isDirectory(cacheDirectory))
+            throw CacheException
+                    .of("The path is not a directory, or the directory cannot be created: " + cacheDirectory);
+        this.cacheDirectory = cacheDirectory;
+        this.activeKeys = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Return the cached ResultSet for the given key.
+     * If the entry does not exist the ResultSet is extracted by calling the given resultSetProvider.
+     * If the entry does not exist and no resultSetProvider is given (null) an SQLException is thrown.
+     *
+     * @param statement         the cached statement
+     * @param key               the generated key for this statement
+     * @param resultSetProvider the optional result provider
+     * @return the cached ResultSet
+     * @throws SQLException if the statement cannot be executed
+     */
+    public CachedOnDiskResultSet get(final CachedStatement statement, final String key, final Provider resultSetProvider)
+            throws SQLException {
+        final Path resultSetPath = cacheDirectory.resolve(key);
+        if (!Files.exists(resultSetPath)) {
+            if (resultSetProvider == null)
+                throw new SQLException("No cache available");
+            buildCache(key, resultSetPath, resultSetProvider);
+        }
+        try {
+            return new CachedOnDiskResultSet(statement, resultSetPath);
+        } catch (IOException e) {
+            throw new SQLException("Can not read cache", e);
+        }
+    }
+
+    private void buildCache(final String key, final Path resultSetPath, final Provider resultSetProvider)
+            throws SQLException {
+        final Lock keyLock = activeKeys.computeIfAbsent(key, s -> new ReentrantLock(true));
+        try {
+            keyLock.lock();
+            try {
+                final Path tempPath = cacheDirectory.resolve(key + ".tmp");
+                try {
+                    final ResultSet providedResultSet = resultSetProvider.provide();
+                    ResultSetWriter.write(tempPath, providedResultSet);
+                    Files.move(tempPath, resultSetPath, StandardCopyOption.REPLACE_EXISTING,
+                            StandardCopyOption.ATOMIC_MOVE);
+                } catch (IOException e) {
+                    throw new SQLException("Failed in renaming the file " + tempPath, e);
+
+                } finally {
+                    try {
+                        Files.deleteIfExists(tempPath);
+                    } catch (IOException e) {
+                        // Quiet
+                    }
+                }
+            } finally {
+                keyLock.unlock();
+            }
+        } finally {
+            activeKeys.remove(key);
+        }
+    }
+
+    /**
+     * Check if an entry is available for this key.
+     *
+     * @param key the computed key
+     * @return always true if the cache entry exists
+     */
+
+    public boolean checkIfExists(final String key) {
+        final Path resultSetPath = cacheDirectory.resolve(key);
+        return Files.exists(resultSetPath);
+    }
+
+    private void parse(final Consumer<Path> consumer) throws SQLException {
+        try {
+            synchronized (cacheDirectory) {
+                Files.list(cacheDirectory).forEach(path -> {
+                    if (!path.endsWith(".tmp"))
+                        consumer.accept(path);
+                });
+            }
+        } catch (CacheException e) {
+            throw e.getSQLException();
+        } catch (IOException e) {
+            throw CacheException.of(e).getSQLException();
+        }
+    }
+
+    @Override
+    public void flush() throws SQLException {
+        parse(path -> {
+            try {
+                Files.deleteIfExists(path);
+            } catch (IOException e) {
+                throw CacheException.of(e);
+            }
+        });
+    }
+
+    private Path checkCacheDirectory() {
+        return Objects.requireNonNull(cacheDirectory, "No cache directory");
+    }
+
+    @Override
+    public void flush(final Statement stmt) throws SQLException {
+        try {
+            Files.deleteIfExists(cacheDirectory.resolve(checkKey(stmt)));
+        } catch (IOException e) {
+            throw CacheException.of(e);
+        }
+    }
+
+    @Override
+    public int size() throws SQLException {
+        final AtomicInteger counter = new AtomicInteger();
+        parse(path -> {
+            if (!path.endsWith(".tmp"))
+                counter.incrementAndGet();
+        });
+        return counter.get();
+    }
+
+    @Override
+    public boolean exists(Statement stmt) throws SQLException {
+        return Files.exists(checkCacheDirectory().resolve(checkKey(stmt)));
+    }
+}

--- a/src/main/java/com/qwazr/jdbc/cache/ResultSetWriter.java
+++ b/src/main/java/com/qwazr/jdbc/cache/ResultSetWriter.java
@@ -36,6 +36,18 @@ class ResultSetWriter {
         }
     }
 
+    static ByteArrayOutputStream write(final ResultSet resultSet) throws SQLException {
+        try (final ByteArrayOutputStream fos = new ByteArrayOutputStream()) {
+            try (final DataOutputStream output = new DataOutputStream(fos)) {
+                writeMetadata(output, resultSet.getMetaData());
+                writeResultSet(output, resultSet);
+                return fos;
+            }
+        } catch (IOException e) {
+            throw new SQLException("Error while writing the ResultSet cache", e);
+        }
+    }
+
     private static void writeMetadata(final DataOutputStream output, final ResultSetMetaData metadata)
             throws IOException, SQLException {
         final int columnCount = metadata.getColumnCount();

--- a/src/test/java/com/qwazr/jdbc/cache/InMemoryCacheDerbyTest.java
+++ b/src/test/java/com/qwazr/jdbc/cache/InMemoryCacheDerbyTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2016 Emmanuel Keller / QWAZR
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.qwazr.jdbc.cache;
+
+import org.junit.FixMethodOrder;
+import org.junit.runners.MethodSorters;
+
+import java.io.File;
+import java.sql.ResultSet;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class InMemoryCacheDerbyTest extends DerbyTest {
+    @Override
+    Class<? extends ResultSet> expectedResultSetClass() {
+        return CachedInMemoryResultSet.class;
+    }
+
+    @Override
+    String getOrSetJdbcCacheUrl() {
+        return "jdbc:cache:mem:foo";
+    }
+
+    @Override
+    String getDerbyDbName() {
+        return "myDB2";
+    }
+}

--- a/src/test/java/com/qwazr/jdbc/cache/OnDiskCacheDerbyTest.java
+++ b/src/test/java/com/qwazr/jdbc/cache/OnDiskCacheDerbyTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2016 Emmanuel Keller / QWAZR
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.qwazr.jdbc.cache;
+
+import org.junit.FixMethodOrder;
+import org.junit.runners.MethodSorters;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.sql.ResultSet;
+
+import static org.junit.Assert.fail;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class OnDiskCacheDerbyTest extends DerbyTest {
+    private static String jdbcCacheUrl = null;
+
+    @Override
+    Class<? extends ResultSet> expectedResultSetClass() {
+        return CachedOnDiskResultSet.class;
+    }
+
+    @Override
+    String getOrSetJdbcCacheUrl() {
+        if (jdbcCacheUrl == null) {
+            String tempDirPath;
+            try {
+                tempDirPath = Files.createTempDirectory("jdbc-cache-test").toUri().getPath();
+                if (tempDirPath.contains(":") && tempDirPath.startsWith("/"))
+                    tempDirPath = tempDirPath.substring(1);
+                jdbcCacheUrl = "jdbc:cache:file:" + tempDirPath + File.separatorChar + "cache";
+            } catch (IOException e) {
+                fail("Can not create the cache dir: " + e.getMessage());
+                return null;
+            }
+        }
+        return jdbcCacheUrl;
+    }
+
+    @Override
+    String getDerbyDbName() {
+        return "myDB1";
+    }
+}


### PR DESCRIPTION
There are some use cases where we know we have enough memory and we want to be as fast as possible so we just want to hold in memory a ResultSet related to a given Statement.

This commit implements a new type of cache using memory instead of hard disk files.

It uses a naive implementation with ByteArrayStreams which is **not recommended for production**.

```java
// Initialize the cache driver
Class.forName("com.qwazr.jdbc.cache.Driver");

// Provide the URL and the Class name of the backend driver
Properties info = new Properties();
info.setProperty("cache.driver.url", "jdbc:derby:memory:myDB;create=true");
info.setProperty("cache.driver.class", "org.apache.derby.jdbc.EmbeddedDriver");
// Get your JDBC connection
Connection cnx = DriverManager.getConnection("jdbc:cache:mem:my-memory-cache", info);
```

The syntax of the URL can be:

* *jdbc:cache:file:{path-to-the-cache-directory}* for on disk cache
* *jdbc:cache:mem:{name-of-the-cache}* for in memory cache