### PR TITLE
Fix Maven and Javadoc warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,12 +85,41 @@
         </dependency>
     </dependencies>
 
-    <prerequisites>
-        <maven>3.0</maven>
-    </prerequisites>
-
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.0</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>enforce-java</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>1.8.0</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/src/main/java/com/qwazr/jdbc/cache/ResultSetCache.java
+++ b/src/main/java/com/qwazr/jdbc/cache/ResultSetCache.java
@@ -33,6 +33,7 @@ public interface ResultSetCache {
      * Remove any cache entry for the given statement.
      *
      * @param stmt the statement to flush
+     * @throws SQLException if any SQL error occurs
      */
     void flush(Statement stmt) throws SQLException;
 
@@ -47,6 +48,7 @@ public interface ResultSetCache {
      *
      * @param stmt the statement to check
      * @return true if a cache entry exists
+     * @throws SQLException if any SQL error occurs
      */
     boolean exists(Statement stmt) throws SQLException;
 
@@ -58,6 +60,7 @@ public interface ResultSetCache {
     /**
      * @param stmt the statement to flush
      * @return true if a cache entry is currently build for the given statement
+     * @throws SQLException if any SQL error occurs
      */
     boolean active(Statement stmt) throws SQLException;
 


### PR DESCRIPTION
`prerequisites.maven` can only be used in the context of writing maven plugins.
To use it in the context of regular projects, you need to use the `maven-enforcer-plugin`.

I added a rule regarding Java8 in addition to the Maven rule.